### PR TITLE
Adding CSRF-mitigation t

### DIFF
--- a/lib/ueberauth/strategy/pocket.ex
+++ b/lib/ueberauth/strategy/pocket.ex
@@ -1,6 +1,6 @@
 defmodule Ueberauth.Strategy.Pocket do
   @moduledoc false
-  use Ueberauth.Strategy, uid_field: :username
+  use Ueberauth.Strategy, uid_field: :username, ignores_csrf_attack: true
 
   alias Ueberauth.Auth.Info
   alias Ueberauth.Auth.Credentials


### PR DESCRIPTION
Found a small fix to make the Pocket Ueberauth strategy workable with the newest Ueberauth enforcing CSRF-attack mitigation via "state" param, The fix disables CSRF for the strategy  (read more [here](https://github.com/ueberauth/ueberauth/issues/)135#issuecomment-925765037)).